### PR TITLE
Update tar package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:edge
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories && \
-    apk add --update build-base ruby ruby-dev libxml2-dev mongodb-tools redis gpgme tzdata && \
+    apk add --update build-base ruby ruby-dev libxml2-dev mongodb-tools redis gpgme tzdata tar && \
     gem install nokogiri -v 1.8.4 --no-document && \
     gem install backup -v 5.0.0.beta.2 --no-document && \
     gem install whenever etc --no-document && \


### PR DESCRIPTION
tar package is outdated in alpine.
For usage of the archive module in Backup, a current tar package is needed